### PR TITLE
B/issue 4 adressing players correctly

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,7 +34,7 @@ type GameState struct {
 }
 
 func createPlayer(n int, ir *bufio.Reader) Player {
-	fmt.Print(string(colorSystem), "Enter player one name: ", string(colorReset))
+	fmt.Print(string(colorSystem), fmt.Sprintf("Enter player %d name: ", n), string(colorReset))
 	name, err := ir.ReadString('\n')
 
 	if err != nil {

--- a/man/tic-tac-goe.1
+++ b/man/tic-tac-goe.1
@@ -16,7 +16,5 @@ Github \- https://github.com/Nopzen/tic-tac-goe/
 Uppercase row letter not working as intended \- https://github.com/Nopzen/tic-tac-goe/issues/1
 
 Auto format for player move \- https://github.com/Nopzen/tic-tac-goe/issues/2
-
-Player two name prompt asks for player one \- https://github.com/Nopzen/tic-tac-goe/issues/4
 .SH AUTHOR
 Lars Krieger (github@larskrieger.io)


### PR DESCRIPTION
### Implements
 - none

### Updates
 - Man update BUG section removing notion of issue #4 

### Fixes
 - Issue while calling `createPlayer` function, it would always ask for player one and never player two, fixed by showing the number of the iterration 1 or 2.